### PR TITLE
Adding I²C write_i2c_block and read_i2c_block methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: c
+compiler:
+- gcc
+
+script: make EXTRA="py-smbus" && make install 
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: c
 compiler:
 - gcc
 
-script: make EXTRA="py-smbus" && make install 
+script: make EXTRA="py-smbus" && sudo make install && cd py-smbus && sudo python setup.py install
 
+sudo: required
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ RM		:= rm -f
 
 CC	?= gcc
 AR	?= ar
+STRIP	?= strip
 
 CFLAGS		?= -O2
 # When debugging, use the following instead

--- a/Makefile
+++ b/Makefile
@@ -59,5 +59,5 @@ all:
 
 EXTRA	:=
 #EXTRA	+= eeprog py-smbus
-SRCDIRS	:= include lib eeprom stub tools $(EXTRA)
+SRCDIRS	:= include lib eeprom eeprog stub tools $(EXTRA)
 include $(SRCDIRS:%=%/Module.mk)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-DESTDIR	=
+DESTDIR	?=
 prefix	= /usr/local
 bindir	= $(prefix)/bin
 sbindir	= $(prefix)/sbin

--- a/README
+++ b/README
@@ -2,6 +2,7 @@
  * By default i2-tools/py-smbus module does not provide an option to forcefully open a i2c-device-address( for safe reasons). But i2get command gives option '-y' to read/write.
  * So i forked i2c-tools/py-smbus in github to allow python code also to have similar option. 
  * I have changed 3 lines in python module code.
+ * Usage of this changed module at: https://github.com/GssMahadevan/chip_axp209_tool
  * Warning : Reading/Writing forcefully a i2c device can have dangerous consequences. So use this carefully.
  
 

--- a/README
+++ b/README
@@ -1,7 +1,8 @@
 ## Changed Content from original sources
  * By default i2-tools/py-smbus module does not provide an option to forcefully open a i2c-device-address( for safe reasons). But i2get command gives option '-y' to read/write.
  * So i forked i2c-tools/py-smbus in github to allow python code also to have similar option. 
-  * I have changed 3 lines in python module code.
+ * I have changed 3 lines in python module code.
+ * Warning : Reading/Writing forcefully a i2c device can have dangerous consequences. So use this carefully.
  
 
 I2C TOOLS FOR LINUX

--- a/README
+++ b/README
@@ -84,6 +84,8 @@ do:
   $ make EXTRA="py-smbus"
 
 
+Do not forget to run "sudo ldconfig" after "make install" and "sudo python setup.py install"
+
 DOCUMENTATION
 -------------
 

--- a/README
+++ b/README
@@ -1,3 +1,9 @@
+## Changed Content from original sources
+ * By default i2-tools/py-smbus module does not provide an option to forcefully open a i2c-device-address( for safe reasons). But i2get command gives option '-y' to read/write.
+ * So i forked i2c-tools/py-smbus in github to allow python code also to have similar option. 
+  * I have changed 3 lines in python module code.
+ 
+
 I2C TOOLS FOR LINUX
 ===================
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ applications. The tools and library compile, run and have been tested on
 GNU/Linux on ODROID, Raspberry Pi and Beaglebone boards.
 
 ## Changed from original sources
- * By default i2-tools/py-smbus module does not provide an option to forcefully open a i2c-device-address (for safe reasons). But i2get command gives option '-y' to read/write.
- * Added the write_i2c_block and read_i2c_block methods
+ * By default i2-tools/py-smbus module does not provide an option to forcefully open a i2c-device-address (for safe reasons). But i2get command gives option `-y` to read/write.
+ * Added the `write_i2c_block` and `read_i2c_block` methods
 
 
 
@@ -22,30 +22,30 @@ CONTENTS
 The various tools included in this package are grouped by category, each
 category has its own sub-directory:
 
-* eeprom
+* eeprom\
   Perl scripts for decoding different types of EEPROMs (SPD, EDID...) These
   scripts rely on the "eeprom" kernel driver. They are installed by default.
 
-* eeprog, eepromer
+* eeprog, eepromer\
   Tools for writing to EEPROMs. These tools rely on the "i2c-dev" kernel
   driver. They are not installed by default.
 
-* include
+* include\
   C/C++ header files for I2C and SMBus access over i2c-dev. Installed by
   default.
 
-* lib
+* lib\
   The I2C library, used by eeprog, py-smbus and tools. Installed by
   default.
 
-* py-smbus
+* py-smbus\
   Python wrapper for SMBus access over i2c-dev. Not installed by default.
 
-* stub
+* stub\
   A helper script to use with the i2c-stub kernel driver. Installed by
   default.
 
-* tools
+* tools\
   I2C device detection and register dump tools. These tools rely on the
   "i2c-dev" kernel driver. They are installed by default.
 
@@ -62,30 +62,31 @@ exceptions.
 INSTALLATION
 ------------
 
-There's no configure script, so simply run "make" to build the library and
-tools, and "make install" to install them. You also can use "make uninstall"
+There's no configure script, so simply run `make` to build the library and
+tools, and `make install` to install them. You also can use `make uninstall`
 to remove all the files you installed. By default, files are installed in
 /usr/local but you can change the location by editing the Makefile file and
 setting prefix to wherever you want. You may change the C compiler and the
 compilation flags as well, and also decide whether to build the static
 library or not.
 
-Optionally, you can run "make strip" prior to "make install" if you want
+Optionally, you can run `make strip` prior to `make install` if you want
 smaller binaries. However, be aware that this will prevent any further
 attempt to debug the library and tools.
 
 If you wish to include sub-directories that are not enabled by default, then
 just set them via the EXTRA make variable. For example, to build py-smbus,
 do:
+```
   $ make EXTRA="py-smbus"
+```
 
-
-Do not forget to run "sudo ldconfig" after "make install" and "sudo python setup.py install"
+Do not forget to run `sudo ldconfig` after `make install` and `sudo python setup.py install`
 
 DOCUMENTATION
 -------------
 
-The main tools have manual pages, which are installed by "make install".
+The main tools have manual pages, which are installed by `make install`.
 See these manual pages for command line interface details and tool specific
 information.
 
@@ -95,9 +96,8 @@ The other tools come with simple text documentation, which isn't installed.
 QUESTIONS AND BUG REPORTS
 -------------------------
 
-Please post your questions and bug reports to the linux-i2c mailing list:
-  linux-i2c@vger.kernel.org
-with Cc to the current maintainer:
-  Jakub Kakona <kaklik@mlab.cz>
+Please post your questions and bug reports to the linux-i2c mailing list: linux-i2c@vger.kernel.org\
+with Cc to the current maintainer: Jakub Kakona <kaklik@mlab.cz>\
+
 For additional information about this list, see:
-  http://vger.kernel.org/vger-lists.html#linux-i2c
+  http://vger.kernel.org/vger-lists.html#linux-i2c/

--- a/README.md
+++ b/README.md
@@ -8,17 +8,11 @@ as well as an I2C library. The tools were originally part of the lm-sensors
 project but were finally split into their own package for convenience. The
 library is used by some of the tools, but can also be used by third-party
 applications. The tools and library compile, run and have been tested on
-GNU/Linux.
-
-The latest version of the code can be downloaded from:
-  http://www.lm-sensors.org/wiki/I2CTools
-
+GNU/Linux on ODROID, Raspberry Pi and Beaglebone boards.
 
 ## Changed from original sources
- * By default i2-tools/py-smbus module does not provide an option to forcefully open a i2c-device-address( for safe reasons). But i2get command gives option '-y' to read/write.
- * So i forked i2c-tools/py-smbus in github to allow python code also to have similar option. 
- * I have changed 3 lines in python module code.
- * Usage of this changed module at: https://github.com/GssMahadevan/chip_axp209_tool
+ * By default i2-tools/py-smbus module does not provide an option to forcefully open a i2c-device-address (for safe reasons). But i2get command gives option '-y' to read/write.
+ * Added the write_i2c_block and read_i2c_block methods
 
 
 
@@ -104,6 +98,6 @@ QUESTIONS AND BUG REPORTS
 Please post your questions and bug reports to the linux-i2c mailing list:
   linux-i2c@vger.kernel.org
 with Cc to the current maintainer:
-  Jean Delvare <jdelvare@suse.de>
+  Jakub Kakona <kaklik@mlab.cz>
 For additional information about this list, see:
   http://vger.kernel.org/vger-lists.html#linux-i2c

--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
-## Changed Content from original sources
- * By default i2-tools/py-smbus module does not provide an option to forcefully open a i2c-device-address( for safe reasons). But i2get command gives option '-y' to read/write.
- * So i forked i2c-tools/py-smbus in github to allow python code also to have similar option. 
- * I have changed 3 lines in python module code.
- * Usage of this changed module at: https://github.com/GssMahadevan/chip_axp209_tool
- * Warning : Reading/Writing forcefully a i2c device can have dangerous consequences. So use this carefully.
- 
+[![Build Status](https://travis-ci.org/MLAB-project/i2c-tools.svg?branch=master)](https://travis-ci.org/MLAB-project/i2c-tools)
 
 I2C TOOLS FOR LINUX
 ===================
@@ -18,6 +12,14 @@ GNU/Linux.
 
 The latest version of the code can be downloaded from:
   http://www.lm-sensors.org/wiki/I2CTools
+
+
+## Changed from original sources
+ * By default i2-tools/py-smbus module does not provide an option to forcefully open a i2c-device-address( for safe reasons). But i2get command gives option '-y' to read/write.
+ * So i forked i2c-tools/py-smbus in github to allow python code also to have similar option. 
+ * I have changed 3 lines in python module code.
+ * Usage of this changed module at: https://github.com/GssMahadevan/chip_axp209_tool
+
 
 
 CONTENTS

--- a/eeprog/Module.mk
+++ b/eeprog/Module.mk
@@ -40,7 +40,7 @@ $(EEPROG_DIR)/24cXX.o: $(EEPROG_DIR)/24cXX.c $(EEPROG_DIR)/24cXX.h $(INCLUDE_DIR
 all-eeprog: $(addprefix $(EEPROG_DIR)/,$(EEPROG_TARGETS))
 
 strip-eeprog: $(addprefix $(EEPROG_DIR)/,$(EEPROG_TARGETS))
-	strip $(addprefix $(EEPROG_DIR)/,$(EEPROG_TARGETS))
+	$(STRIP) $(addprefix $(EEPROG_DIR)/,$(EEPROG_TARGETS))
 
 clean-eeprog:
 	$(RM) $(addprefix $(EEPROG_DIR)/,*.o $(EEPROG_TARGETS))

--- a/lib/Module.mk
+++ b/lib/Module.mk
@@ -73,7 +73,7 @@ $(LIB_DIR)/smbus.ao: $(LIB_DIR)/smbus.c $(INCLUDE_DIR)/i2c/smbus.h
 all-lib: $(addprefix $(LIB_DIR)/,$(LIB_TARGETS) $(LIB_LINKS))
 
 strip-lib: $(addprefix $(LIB_DIR)/,$(LIB_TARGETS))
-	strip $(addprefix $(LIB_DIR)/,$(LIB_TARGETS))
+	$(STRIP) $(addprefix $(LIB_DIR)/,$(LIB_TARGETS))
 
 clean-lib:
 	$(RM) $(addprefix $(LIB_DIR)/,*.o *.ao $(LIB_TARGETS) $(LIB_LINKS))

--- a/py-smbus/Module.mk
+++ b/py-smbus/Module.mk
@@ -22,7 +22,7 @@ clean-python:
 	rm -rf py-smbus/build
 
 install-python:
-	$(DISTUTILS) install
+	$(DISTUTILS) install --root=$(DESTDIR) --prefix=$(prefix)
 
 all: all-python
 

--- a/py-smbus/setup.py
+++ b/py-smbus/setup.py
@@ -11,10 +11,14 @@ setup(	name="smbus",
 	maintainer_email="linux-i2c@vger.kernel.org",
 	license="GPLv2",
 	url="http://lm-sensors.org/",
-	ext_modules=[Extension(
-		"smbus",
-		["smbusmodule.c"],
-		extra_compile_args=['-I../include'],
-		extra_link_args=['-L../lib', '-li2c']
-	)]
+	ext_modules=[
+                    Extension(
+		            name="smbus",
+		            sources=["smbusmodule.c"],
+	                library_dirs=["../lib"],
+	                libraries=["i2c"],
+		            extra_compile_args=['-I../include'],
+		            extra_link_args=['-L../lib', '-li2c']
+                	)
+                ]
 )

--- a/py-smbus/setup.py
+++ b/py-smbus/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup, Extension
 
 setup(	name="smbus",
-	version="1.1",
+	version="1.2",
 	description="Python bindings for Linux SMBus access through i2c-dev",
 	author="Mark M. Hoffman",
 	author_email="mhoffman@lightlink.com",

--- a/py-smbus/setup.py
+++ b/py-smbus/setup.py
@@ -11,4 +11,12 @@ setup(	name="smbus",
 	maintainer_email="linux-i2c@vger.kernel.org",
 	license="GPLv2",
 	url="http://lm-sensors.org/",
-	ext_modules=[Extension("smbus", ["smbusmodule.c"])])
+	ext_modules=[
+	                Extension(
+	                name="smbus",
+	                sources=["smbusmodule.c"],
+	                library_dirs=["../lib"],
+	                libraries=["i2c"]
+	                )
+	            ]
+    )

--- a/py-smbus/smbusmodule.c
+++ b/py-smbus/smbusmodule.c
@@ -532,8 +532,7 @@ SMBus_read_i2c_block(SMBus *self, PyObject *args)
 
     SMBus_SET_ADDR(self, addr);
 
-    /* save a bit of code by calling the i2c_master_recv function directly */
-    if (i2c_master_recv(self->fd, &data, len)) {
+    if (read(self->fd, &data, len) != len) {
         PyErr_SetFromErrno(PyExc_IOError);
         return NULL;
     }
@@ -549,17 +548,16 @@ PyDoc_STRVAR(SMBus_write_i2c_block_doc,
 static PyObject *
 SMBus_write_i2c_block(SMBus *self, PyObject *args)
 {
-    int addr;
+    int addr, len =32;
     union i2c_smbus_data data;
 
-    if (!PyArg_ParseTuple(args, "iiO&:write_i2c_block", &addr,
+    if (!PyArg_ParseTuple(args, "iiO&:write_i2c_block", &addr, &len, 
             SMBus_list_to_data, &data))
         return NULL;
 
     SMBus_SET_ADDR(self, addr);
 
-    /* save a bit of code by calling the access function directly */
-    if (i2c_master_send(self->fd, &data)) {
+    if (write(self->fd, &data, len) != len) {
         PyErr_SetFromErrno(PyExc_IOError);
         return NULL;
     }

--- a/py-smbus/smbusmodule.c
+++ b/py-smbus/smbusmodule.c
@@ -5,12 +5,12 @@
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; version 2 of the License.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
@@ -25,6 +25,11 @@
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 #include <i2c/smbus.h>
+
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_Check(value) PyLong_Check(value)
+#define PyInt_AS_LONG(value) PyLong_AS_LONG(value)
+#endif
 
 /*
 ** These are required to build this module against Linux older than 2.6.23.
@@ -94,7 +99,7 @@ SMBus_dealloc(SMBus *self)
 	PyObject *ref = SMBus_close(self);
 	Py_XDECREF(ref);
 
-	self->ob_type->tp_free((PyObject *)self);
+    Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
 #define MAXPATH 16
@@ -434,7 +439,7 @@ SMBus_list_to_data(PyObject *list, union i2c_smbus_data *data)
 
 	for (ii = 0; ii < len; ii++) {
 		PyObject *val = PyList_GET_ITEM(list, ii);
-		if (!PyInt_Check(val)) {
+        if (!PyInt_Check(val)) {
 			PyErr_SetString(PyExc_TypeError, msg);
 			return 0; /* fail */
 		}
@@ -614,7 +619,7 @@ SMBus_set_pec(SMBus *self, PyObject *val, void *closure)
 		return -1;
 	}
 	else if (pec == -1) {
-		PyErr_SetString(PyExc_TypeError, 
+		PyErr_SetString(PyExc_TypeError,
 			"The pec attribute must be a boolean.");
 		return -1;
 	}
@@ -637,8 +642,7 @@ static PyGetSetDef SMBus_getset[] = {
 };
 
 static PyTypeObject SMBus_type = {
-	PyObject_HEAD_INIT(NULL)
-	0,				/* ob_size */
+    PyVarObject_HEAD_INIT(NULL, 0)
 	"smbus.SMBus",			/* tp_name */
 	sizeof(SMBus),			/* tp_basicsize */
 	0,				/* tp_itemsize */
@@ -682,20 +686,38 @@ static PyMethodDef SMBus_module_methods[] = {
 	{NULL}
 };
 
-#ifndef PyMODINIT_FUNC	/* declarations for DLL import/export */
-#define PyMODINIT_FUNC void
+#if PY_MAJOR_VERSION >= 3
+  #define MOD_ERROR_VAL NULL
+  #define MOD_SUCCESS_VAL(val) val
+  #define MOD_INIT(name) PyMODINIT_FUNC PyInit_##name(void)
+  #define MOD_DEF(ob, name, doc, methods) \
+          static struct PyModuleDef moduledef = { \
+            PyModuleDef_HEAD_INIT, name, doc, -1, methods, }; \
+          ob = PyModule_Create(&moduledef);
+#else
+  #define MOD_ERROR_VAL
+  #define MOD_SUCCESS_VAL(val)
+  #define MOD_INIT(name) void init##name(void)
+  #define MOD_DEF(ob, name, doc, methods) \
+          ob = Py_InitModule3(name, methods, doc);
 #endif
-PyMODINIT_FUNC
-initsmbus(void) 
+
+MOD_INIT(smbus)
 {
-	PyObject* m;
+    PyObject *m;
 
-	if (PyType_Ready(&SMBus_type) < 0)
-		return;
+    MOD_DEF(m, "smbus", SMBus_module_doc,
+            SMBus_module_methods)
 
-	m = Py_InitModule3("smbus", SMBus_module_methods, SMBus_module_doc);
+    if (m == NULL)
+        return MOD_ERROR_VAL;
 
-	Py_INCREF(&SMBus_type);
-	PyModule_AddObject(m, "SMBus", (PyObject *)&SMBus_type);
+    if (PyType_Ready(&SMBus_type) < 0)
+        return MOD_ERROR_VAL;
+
+    Py_INCREF(&SMBus_type);
+    PyModule_AddObject(m, "SMBus", (PyObject *)&SMBus_type);
+
+    return MOD_SUCCESS_VAL(m);
 }
 

--- a/py-smbus/smbusmodule.c
+++ b/py-smbus/smbusmodule.c
@@ -49,8 +49,9 @@ typedef struct {
 	PyObject_HEAD
 
 	int fd;		/* open file descriptor: /dev/i2c-?, or -1 */
-	int addr;	/* current client SMBus address */
+	int addr;	/* current client SMBus address */
 	int pec;	/* !0 => Packet Error Codes enabled */
+	int force;      /* force loading the module depsite device busy */
 } SMBus;
 
 static PyObject *
@@ -64,7 +65,8 @@ SMBus_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 	self->fd = -1;
 	self->addr = -1;
 	self->pec = 0;
-
+        self->force =  getenv("PY_SMBUS") != NULL ;
+        
 	return (PyObject *)self;
 }
 
@@ -162,7 +164,7 @@ SMBus_set_addr(SMBus *self, int addr)
 	int ret = 0;
 
 	if (self->addr != addr) {
-		ret = ioctl(self->fd, I2C_SLAVE, addr);
+		ret = ioctl(self->fd, (self->force ? I2C_SLAVE_FORCE : I2C_SLAVE), addr);
 		self->addr = addr;
 	}
 

--- a/py-smbus/smbusmodule.c
+++ b/py-smbus/smbusmodule.c
@@ -810,12 +810,13 @@ static struct PyModuleDef SMBusModule = {
 #define INIT_RETURN(m)	return m
 #define INIT_FNAME	PyInit_smbus
 #else
-static PyMethodDef SMBus_module_methods[] = {
-	{NULL}
-};
 #define INIT_RETURN(m)	return
 #define INIT_FNAME	initsmbus
 #endif
+
+static PyMethodDef SMBus_module_methods[] = {
+    {NULL}
+};
 
 #if PY_MAJOR_VERSION >= 3
   #define MOD_ERROR_VAL NULL

--- a/py-smbus/smbusmodule.c
+++ b/py-smbus/smbusmodule.c
@@ -49,7 +49,7 @@ typedef struct {
 	PyObject_HEAD
 
 	int fd;		/* open file descriptor: /dev/i2c-?, or -1 */
-	int addr;	/* current client SMBus address */
+	int addr;	/* current client SMBus address */
 	int pec;	/* !0 => Packet Error Codes enabled */
 	int force;      /* force loading the module depsite device busy */
 } SMBus;

--- a/py-smbus/smbusmodule.c
+++ b/py-smbus/smbusmodule.c
@@ -464,7 +464,7 @@ SMBus_list_to_data(PyObject *list, union i2c_smbus_data *data)
 }
 
 static int
-SMBus_list_to_array(PyObject *list, char *data, int *len)
+SMBus_list_to_array(PyObject *list, char* data, int* len)
 {
     static char *msg = "Second argument must be a list of at least one, "
                 "but not more than 32 integers";
@@ -479,8 +479,10 @@ SMBus_list_to_array(PyObject *list, char *data, int *len)
         PyErr_SetString(PyExc_OverflowError, msg);
         return 0; /* fail */
     }
+    
+    printf("\r\n\r\n converting list size of %d and to array \r\n\r\n", lenght);
 
-    len = &lenght;
+    //*len = lenght;
 
     for (ii = 0; ii < lenght; ii++) {
         PyObject *val = PyList_GET_ITEM(list, ii);
@@ -571,8 +573,12 @@ SMBus_read_i2c_block(SMBus *self, PyObject *args)
         return NULL;
 
     SMBus_SET_ADDR(self, addr);
+    printf("\r\n\r\n reading i2c block from address %x and lenght %d \r\n\r\n", addr, len);
+
 
     if (read(self->fd, data, len) != len) {
+        printf("\r\n\r\n ERROR OCCURED! errno value: %d. \r\n\r\n", errno); \
+
         PyErr_SetFromErrno(PyExc_IOError);
         return NULL;
     }
@@ -587,13 +593,24 @@ PyDoc_STRVAR(SMBus_write_i2c_block_doc,
 static PyObject *
 SMBus_write_i2c_block(SMBus *self, PyObject *args)
 {
-    int addr, len =32;
-    unsigned char data[len];
+    int addr, len=32;
+    char data[len];
+    PyObject *listObj;  /* the list of tranmit data */
 
-    if (!PyArg_ParseTuple(args, "iO&:write_i2c_block", &addr, SMBus_list_to_array, &data, &len))
+    /*if (!PyArg_ParseTuple(args, "iO!:write_i2c_block", &addr, &PyList_Type, &listObj))
         return NULL;
 
+    printf("\r\n\r\n Converting python list \r\n\r\n");
+
+    SMBus_list_to_array(listObj, data, &len);*/
+
+    printf("\r\n\r\n Converting python list \r\n\r\n");
+    if (!PyArg_ParseTuple(args, "iO&:write_i2c_block", &addr, SMBus_list_to_array, &data, &len))
+        return NULL;
+    len = 3;
+
     SMBus_SET_ADDR(self, addr);
+    printf("\r\n\r\n writing i2c block to address %x and lenght %d %x \r\n\r\n", addr, len, data[1]);
 
     if (write(self->fd, data, len) != len) {
         PyErr_SetFromErrno(PyExc_IOError);

--- a/py-smbus/smbusmodule.c
+++ b/py-smbus/smbusmodule.c
@@ -589,28 +589,16 @@ SMBus_write_i2c_block(SMBus *self, PyObject *args)
 {
     int addr, len =32;
     unsigned char data[len];
-    char buf[10];
-
 
     if (!PyArg_ParseTuple(args, "iO&:write_i2c_block", &addr, SMBus_list_to_array, &data, &len))
         return NULL;
 
     SMBus_SET_ADDR(self, addr);
 
-    /*if (write(self->fd, 13, len) != len) {
+    if (write(self->fd, data, len) != len) {
         PyErr_SetFromErrno(PyExc_IOError);
         return NULL;
-    }*/
-
-    buf[0] = 0x25;
-    buf[1] = 0x43;
-    buf[2] = 0x65;
-
-    /*if (write(self->fd, buf, 3) != 3) {
-        PyErr_SetFromErrno(PyExc_IOError);
-        return NULL;
-    }*/
-
+    }
 
     Py_INCREF(Py_None);
     return Py_None;

--- a/py-smbus/smbusmodule.c
+++ b/py-smbus/smbusmodule.c
@@ -479,10 +479,8 @@ SMBus_list_to_array(PyObject *list, char* data, int* len)
         PyErr_SetString(PyExc_OverflowError, msg);
         return 0; /* fail */
     }
-    
-    printf("\r\n\r\n converting list size of %d and to array \r\n\r\n", lenght);
 
-    //*len = lenght;
+    *len = lenght;
 
     for (ii = 0; ii < lenght; ii++) {
         PyObject *val = PyList_GET_ITEM(list, ii);
@@ -573,12 +571,8 @@ SMBus_read_i2c_block(SMBus *self, PyObject *args)
         return NULL;
 
     SMBus_SET_ADDR(self, addr);
-    printf("\r\n\r\n reading i2c block from address %x and lenght %d \r\n\r\n", addr, len);
-
 
     if (read(self->fd, data, len) != len) {
-        printf("\r\n\r\n ERROR OCCURED! errno value: %d. \r\n\r\n", errno); \
-
         PyErr_SetFromErrno(PyExc_IOError);
         return NULL;
     }
@@ -595,22 +589,13 @@ SMBus_write_i2c_block(SMBus *self, PyObject *args)
 {
     int addr, len=32;
     char data[len];
-    PyObject *listObj;  /* the list of tranmit data */
+    PyObject *datalist;  /* the list of data to write */
 
-    /*if (!PyArg_ParseTuple(args, "iO!:write_i2c_block", &addr, &PyList_Type, &listObj))
+    if (!PyArg_ParseTuple(args, "iO!:write_i2c_block", &addr, &PyList_Type, &datalist))
         return NULL;
 
-    printf("\r\n\r\n Converting python list \r\n\r\n");
-
-    SMBus_list_to_array(listObj, data, &len);*/
-
-    printf("\r\n\r\n Converting python list \r\n\r\n");
-    if (!PyArg_ParseTuple(args, "iO&:write_i2c_block", &addr, SMBus_list_to_array, &data, &len))
-        return NULL;
-    len = 3;
-
+    SMBus_list_to_array(datalist, data, &len);
     SMBus_SET_ADDR(self, addr);
-    printf("\r\n\r\n writing i2c block to address %x and lenght %d %x \r\n\r\n", addr, len, data[1]);
 
     if (write(self->fd, data, len) != len) {
         PyErr_SetFromErrno(PyExc_IOError);

--- a/tools/Module.mk
+++ b/tools/Module.mk
@@ -65,7 +65,7 @@ $(TOOLS_DIR)/util.o: $(TOOLS_DIR)/util.c $(TOOLS_DIR)/util.h
 all-tools: $(addprefix $(TOOLS_DIR)/,$(TOOLS_TARGETS))
 
 strip-tools: $(addprefix $(TOOLS_DIR)/,$(TOOLS_TARGETS))
-	strip $(addprefix $(TOOLS_DIR)/,$(TOOLS_TARGETS))
+	$(STRIP) $(addprefix $(TOOLS_DIR)/,$(TOOLS_TARGETS))
 
 clean-tools:
 	$(RM) $(addprefix $(TOOLS_DIR)/,*.o $(TOOLS_TARGETS))

--- a/tools/i2cbusses.c
+++ b/tools/i2cbusses.c
@@ -23,7 +23,7 @@
 */
 
 /* For strdup and snprintf */
-#define _BSD_SOURCE 1
+#define _DEFAULT_SOURCE 1
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/tools/i2cget.c
+++ b/tools/i2cget.c
@@ -41,14 +41,16 @@ static void help(void) __attribute__ ((noreturn));
 static void help(void)
 {
 	fprintf(stderr,
-		"Usage: i2cget [-f] [-y] I2CBUS CHIP-ADDRESS [DATA-ADDRESS [MODE]]\n"
+		"Usage: i2cget [-f] [-y] I2CBUS CHIP-ADDRESS [DATA-ADDRESS [MODE] [LENGTH]]\n"
 		"  I2CBUS is an integer or an I2C bus name\n"
 		"  ADDRESS is an integer (0x03 - 0x77)\n"
 		"  MODE is one of:\n"
 		"    b (read byte data, default)\n"
 		"    w (read word data)\n"
 		"    c (write byte/read byte)\n"
-		"    Append p for SMBus PEC\n");
+		"    i (read I2C block data)\n"
+		"    Append p for SMBus PEC\n"
+		"  LENGTH is length for block data reads\n");
 	exit(1);
 }
 
@@ -89,6 +91,13 @@ static int check_funcs(int file, int size, int daddress, int pec)
 			return -1;
 		}
 		break;
+
+	case I2C_SMBUS_I2C_BLOCK_DATA:
+		if (!(funcs & I2C_FUNC_SMBUS_READ_I2C_BLOCK)) {
+			fprintf(stderr, MISSING_FUNC_FMT, "SMBus read I2C block data");
+			return -1;
+		}
+		break;
 	}
 
 	if (pec
@@ -101,7 +110,7 @@ static int check_funcs(int file, int size, int daddress, int pec)
 }
 
 static int confirm(const char *filename, int address, int size, int daddress,
-		   int pec)
+		   int length, int pec)
 {
 	int dont = 0;
 
@@ -132,11 +141,14 @@ static int confirm(const char *filename, int address, int size, int daddress,
 		fprintf(stderr, "current data\naddress");
 	else
 		fprintf(stderr, "data address\n0x%02x", daddress);
-	fprintf(stderr, ", using %s.\n",
-		size == I2C_SMBUS_BYTE ? (daddress < 0 ?
-		"read byte" : "write byte/read byte") :
-		size == I2C_SMBUS_BYTE_DATA ? "read byte data" :
-		"read word data");
+        if (size == I2C_SMBUS_I2C_BLOCK_DATA)
+            fprintf(stderr, ", %d bytes using read I2C block data.\n", bytes);
+        else
+            fprintf(stderr, ", using %s.\n",
+                    size == I2C_SMBUS_BYTE ? (daddress < 0 ?
+                    "read byte" : "write byte/read byte") :
+                    size == I2C_SMBUS_BYTE_DATA ? "read byte data" :
+                    "read word data");
 	if (pec)
 		fprintf(stderr, "PEC checking enabled.\n");
 
@@ -159,6 +171,8 @@ int main(int argc, char *argv[])
 	int pec = 0;
 	int flags = 0;
 	int force = 0, yes = 0, version = 0;
+	int length;
+	__u8 block_data[I2C_SMBUS_BLOCK_MAX];
 
 	/* handle (optional) flags first */
 	while (1+flags < argc && argv[1+flags][0] == '-') {
@@ -208,11 +222,26 @@ int main(int argc, char *argv[])
 		case 'b': size = I2C_SMBUS_BYTE_DATA; break;
 		case 'w': size = I2C_SMBUS_WORD_DATA; break;
 		case 'c': size = I2C_SMBUS_BYTE; break;
+		case 'i': size = I2C_SMBUS_I2C_BLOCK_DATA; break;
 		default:
 			fprintf(stderr, "Error: Invalid mode!\n");
 			help();
 		}
 		pec = argv[flags+4][1] == 'p';
+	}
+
+	if (argc > flags + 5) {
+		if (size != I2C_SMBUS_I2C_BLOCK_DATA) {
+			fprintf(stderr, "Error: Length only valid for I2C block data!\n");
+			help();
+		}
+		length = strtol(argv[flags+5], &end, 0);
+		if (*end || length < 1 || length > I2C_SMBUS_BLOCK_MAX) {
+			fprintf(stderr, "Error: Length invalid!\n");
+			help();
+		}
+	} else {
+		length = I2C_SMBUS_BLOCK_MAX;
 	}
 
 	file = open_i2c_dev(i2cbus, filename, sizeof(filename), 0);
@@ -221,7 +250,7 @@ int main(int argc, char *argv[])
 	 || set_slave_addr(file, address, force))
 		exit(1);
 
-	if (!yes && !confirm(filename, address, size, daddress, pec))
+	if (!yes && !confirm(filename, address, size, daddress, length, pec))
 		exit(0);
 
 	if (pec && ioctl(file, I2C_PEC, 1) < 0) {
@@ -243,6 +272,9 @@ int main(int argc, char *argv[])
 	case I2C_SMBUS_WORD_DATA:
 		res = i2c_smbus_read_word_data(file, daddress);
 		break;
+	case I2C_SMBUS_I2C_BLOCK_DATA:
+		res = i2c_smbus_read_i2c_block_data(file, daddress, length, block_data);
+		break;
 	default: /* I2C_SMBUS_BYTE_DATA */
 		res = i2c_smbus_read_byte_data(file, daddress);
 	}
@@ -253,7 +285,16 @@ int main(int argc, char *argv[])
 		exit(2);
 	}
 
-	printf("0x%0*x\n", size == I2C_SMBUS_WORD_DATA ? 4 : 2, res);
+	if (size == I2C_SMBUS_I2C_BLOCK_DATA) {
+		int i;
+                printf("%d:", res);
+		for (i = 0; i < res; ++i) {
+			printf(" 0x%02hhx", block_data[i]);
+		}
+		printf("\n");
+	} else {
+		printf("0x%0*x\n", size == I2C_SMBUS_WORD_DATA ? 4 : 2, res);
+	}
 
 	exit(0);
 }

--- a/tools/i2cget.c
+++ b/tools/i2cget.c
@@ -143,7 +143,7 @@ static int confirm(const char *filename, int address, int size, int daddress,
 	else
 		fprintf(stderr, "data address\n0x%02x", daddress);
         if (size == I2C_SMBUS_I2C_BLOCK_DATA)
-            fprintf(stderr, ", %d bytes using read I2C block data.\n", bytes);
+            fprintf(stderr, ", %d bytes using read I2C block data.\n", length);
         else
             fprintf(stderr, ", using %s.\n",
                     size == I2C_SMBUS_BYTE ? (daddress < 0 ?
@@ -198,11 +198,11 @@ int main(int argc, char *argv[])
 	if (argc < flags + 3)
 		help();
 
-	i2cbus = lookup_i2c_bus(argv[flags+1]);
+	i2cbus = i2c_lookup_i2c_bus(argv[flags+1]);
 	if (i2cbus < 0)
 		help();
 
-	address = parse_i2c_address(argv[flags+2]);
+	address = i2c_parse_i2c_address(argv[flags+2]);
 	if (address < 0)
 		help();
 
@@ -245,10 +245,10 @@ int main(int argc, char *argv[])
 		length = I2C_SMBUS_BLOCK_MAX;
 	}
 
-	file = open_i2c_dev(i2cbus, filename, sizeof(filename), 0);
+	file = i2c_open_i2c_dev(i2cbus, filename, sizeof(filename), 0);
 	if (file < 0
 	 || check_funcs(file, size, daddress, pec)
-	 || set_slave_addr(file, address, force))
+	 || i2c_set_slave_addr(file, address, force))
 		exit(1);
 
 	if (!yes && !confirm(filename, address, size, daddress, length, pec))

--- a/tools/i2ctransfer.8
+++ b/tools/i2ctransfer.8
@@ -1,0 +1,51 @@
+.TH i2ctransfer 8 "November 2016"
+.SH "NAME"
+i2ctransfer \- read from I2C/SMBus chip registers
+
+.SH SYNOPSIS
+.B i2ctransfer
+.RB [ -f ]
+.RB [ -y ]
+.I i2ctransfer
+.I chip-address
+.RI [ "data-address " [ mode ]]
+.br
+.B i2ctransfer
+.B -V
+
+.SH DESCRIPTION
+i2ctransfer is a small helper program to read registers visible through the I2C
+bus (or SMBus).
+
+.SH OPTIONS
+.TP
+.B -V
+Display the version and exit.
+.TP
+.B -f
+Force access to the device even if it is already busy. By default, i2ctransfer
+will refuse to access a device which is already under the control of a
+kernel driver. Using this flag is dangerous, it can seriously confuse the
+kernel driver in question. It can also cause i2cget to return an invalid
+value. So use at your own risk and only if you know what you're doing.
+.TP
+.B -y
+Disable interactive mode. By default, i2ctransfer will wait for a confirmation
+from the user before messing with the I2C bus. When this flag is used, it
+will perform the operation directly. This is mainly meant to be used in
+scripts. Use with caution.
+
+.SH WARNING
+i2ctransfer can be extremely dangerous if used improperly. I2C and SMBus are designed
+in such a way that an SMBus read transaction can be seen as a write transaction by
+certain chips. This is particularly true if setting \fImode\fR to \fBcp\fP (write byte/read
+byte with PEC). Be extremely careful using this program.
+
+.SH SEE ALSO
+i2cdump(8), i2cset(8)
+
+.SH AUTHOR
+Jean Delvare
+
+This manual page was strongly inspired from those written by David Z Maze
+for i2cset.


### PR DESCRIPTION
The write_i2c_block and read_i2c_block methods are required for some true I²C sensors like [SHT31](https://www.sensirion.com/en/environmental-sensors/humidity-sensors/digital-humidity-sensors-for-various-applications/) or [SDP610](https://www.sensirion.com/en/flow-sensors/differential-pressure-sensors/digital-differential-pressure-sensors-without-zero-point-drift/). 